### PR TITLE
Optional fallback

### DIFF
--- a/lib/cdnjs-rails/invalid_config.rb
+++ b/lib/cdnjs-rails/invalid_config.rb
@@ -1,0 +1,11 @@
+module CDNJS
+  # Exception raised when a configuration entry for a library is invalid
+  class InvalidConfig < StandardError
+    attr_reader :library
+
+    def initialize(library)
+      @library = library
+      super("Invalid configuration for library #{library.inspect}")
+    end
+  end
+end

--- a/lib/cdnjs-rails/view_helpers.rb
+++ b/lib/cdnjs-rails/view_helpers.rb
@@ -5,24 +5,31 @@ module CDNJS
       js_string_output = Array.new
 
       cdn_vars.each do |js_file_config|
-        window_var = js_file_config.fetch(:windowvar)
-        split_vars = window_var.split(".")
-        window_path = ""
+        cdnjs_path = js_file_config.fetch(:cdnjs, nil)
+        window_var = js_file_config.fetch(:windowvar, nil)
+        local_path = js_file_config.fetch(:localpath, nil)
 
-        split_vars.each_with_index do |val, index|
-          var_check = ["window"]
+        # Output cdnjs loading tag
+        js_string_output << javascript_include_tag("//cdnjs.cloudflare.com/ajax/libs/#{cdnjs_path}")
 
-          0.upto(index) do |i|
-            var_check.push split_vars[i]
+        # Only print fallback code if fallback parameters have been specified
+        if window_var and local_path
+          split_vars = window_var.split(".")
+          window_path = ""
+
+          split_vars.each_with_index do |val, index|
+            var_check = ["window"]
+
+            0.upto(index) do |i|
+              var_check.push split_vars[i]
+            end
+
+            window_path << var_check.join(".") + " && "
           end
 
-          window_path << var_check.join(".") + " && "
+          window_path.chomp!(" && ")
+          js_string_output << javascript_tag("(#{window_path}) || document.write(unescape(\"%3Cscript src='#{asset_path(local_path).gsub('<','%3C')}' type='text/javascript'%3E%3C/script%3E\"))")
         end
-
-        window_path.chomp!(" && ")
-
-        js_string_output << javascript_include_tag("//cdnjs.cloudflare.com/ajax/libs/#{js_file_config.fetch(:cdnjs)}")
-        js_string_output << javascript_tag("(#{window_path}) || document.write(unescape(\"%3Cscript src='#{asset_path(js_file_config.fetch(:localpath)).gsub('<','%3C')}' type='text/javascript'%3E%3C/script%3E\"))")
       end
 
       js_string_output.join("\n").html_safe

--- a/lib/cdnjs-rails/view_helpers.rb
+++ b/lib/cdnjs-rails/view_helpers.rb
@@ -9,6 +9,11 @@ module CDNJS
         window_var = js_file_config.fetch(:windowvar, nil)
         local_path = js_file_config.fetch(:localpath, nil)
 
+        # Ensure cdnjs has been given
+        unless cdnjs_path
+          raise CDNJS::InvalidConfig.new(js_file_config)
+        end
+
         # Output cdnjs loading tag
         js_string_output << javascript_include_tag("//cdnjs.cloudflare.com/ajax/libs/#{cdnjs_path}")
 


### PR DESCRIPTION
This PR changes how configuration is handled:
* If the `:cdnjs` key is missing from a library specification, a `CDNJS::InvalidConfig` exception is raised instead of a plain `KeyError`, for easier debugging.
* Both `:windowvar` and `:localpath` are now optional, so no fallback code is generated if desired by the user of this gem.